### PR TITLE
Update readme for Valiant Vidar 7.1.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # Installation
 
-**Before building iOS Libraries, please have a look at the [Pre-requisites](#pre-requisites)**
-
 1. Clone the repository.
 ```sh
-git clone https://github.com/fotolockr/CakeWallet.git
+git clone https://github.com/loki-project/loki-ios-wallet.git
 ```
 2. Install [homebrew](https://brew.sh/)
 3. Install loki dependencies:
 ```sh
 brew install pkgconfig
 brew install cmake
-brew install zeromq
 ```
 4. Build the loki iOS libraries.
 ```sh
@@ -22,23 +19,6 @@ brew install zeromq
 ```sh
 pod install
 ```
-
-### Shared library building problems
-
-You may get an error such as:
-```
-ld: symbol(s) not found for architecture armv7
-```
-
-If you get this issue then make sure that boost has been correctly built. You can check this by seeing if it exists at `Libraries/boost/builds/libs`. If the folder doesn't exist then run `./scripts/install_boost.sh` in the root director and check to see if any errors occur there.
-
-### XCode Building problems
-If you're having problems building with Xcode 10 or above then change to the `Legacy Build System`
-
-# TEMP FIX TO BUILD LOKI SHARED LIBRARIES
-
-Currently you will fail to build the loki shared libraries because of some errors.
-Apply the changes from `loki-ios-patch.diff` to the loki folder located in `Libraries/`
 
 # Testnet
 


### PR DESCRIPTION
- Pre-requisites don't exist anymore(?)
- Remove build problems section, there shouldn't be anymore build
problems by default (should all be handled in scripts)
- Remove zeromq from dependencies, this is included via LokiMQ